### PR TITLE
Removed errant namespace reference

### DIFF
--- a/Services/ChatService.cs
+++ b/Services/ChatService.cs
@@ -1,5 +1,4 @@
-﻿using Azure.AI.OpenAI;
-using Cosmos.Chat.GPT.Constants;
+﻿using Cosmos.Chat.GPT.Constants;
 using Cosmos.Chat.GPT.Models;
 
 namespace Cosmos.Chat.GPT.Services;


### PR DESCRIPTION
ChatService referenced `Azure.AI.OpenAI` which would break the lab.