### PR TITLE
Use PSRule security audit tool and only test new bicep

### DIFF
--- a/.github/workflows/bicep-audit.yml
+++ b/.github/workflows/bicep-audit.yml
@@ -21,15 +21,23 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: Run Microsoft Security DevOps Analysis
-        uses: microsoft/security-devops-action@preview
-        id: msdo
-        continue-on-error: true
+      - name: Run PSRule analysis
+        uses: microsoft/ps-rule@v2.9.0
         with:
-          tools: templateanalyzer
+          modules: PSRule.Rules.Azure
+          baseline: Azure.Pillar.Security
+          inputPath: infra/*.test.bicep
+          outputFormat: Sarif
+          outputPath: reports/ps-rule-results.sarif
+          summary: true
+        continue-on-error: true
+          
+        env:
+          PSRULE_CONFIGURATION_AZURE_BICEP_FILE_EXPANSION: 'true'
+          PSRULE_CONFIGURATION_AZURE_BICEP_FILE_EXPANSION_TIMEOUT: '30'
 
-      - name: Upload alerts to Security tab
+      - name: Upload results to security tab
         uses: github/codeql-action/upload-sarif@v3
         if: github.repository_owner == 'Azure-Samples'
         with:
-          sarif_file: ${{ steps.msdo.outputs.sarifFile }}
+          sarif_file: reports/ps-rule-results.sarif

--- a/infra/main.test.bicep
+++ b/infra/main.test.bicep
@@ -1,0 +1,17 @@
+// This file is for doing static analysis and contains sensible defaults
+// for the bicep analyser to minimise false-positives and provide the best results.
+
+// This file is not intended to be used as a runtime configuration file.
+
+targetScope = 'subscription'
+
+param environmentName string = 'testing'
+param location string = 'westeurope'
+
+module main 'main.bicep' = {
+  name: 'main'
+  params: {
+    environmentName: environmentName
+    location: location
+  }
+}

--- a/ps-rule.yaml
+++ b/ps-rule.yaml
@@ -1,0 +1,5 @@
+# YAML: Set the AZURE_BICEP_FILE_EXPANSION configuration option to enable expansion
+configuration:
+  AZURE_BICEP_FILE_EXPANSION: true
+  AZURE_DEPLOYMENT_NONSENSITIVE_PARAMETER_NAMES:
+   - resourceToken


### PR DESCRIPTION
This changes the security testing to only test `infra/main.bicep` because at the moment it's picking up the ARM-compiled files in the project root and the ones in `infra/PrevVersion`.

It will close half of the active security issues on this project (which are duplicates)